### PR TITLE
Added python-lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information, please refer to the project [proposal](https://wiki.sugarl
 1. Install the dependencies. If you are using Fedora 20 like I am it is as simple as running:
 
  ```bash
- sudo yum install pocketsphinx pocketsphinx-libs pocketsphinx-plugin pocketsphinx-devel pocketsphinx-python pocketsphinx-models git python-setuptools
+ sudo yum install pocketsphinx pocketsphinx-libs pocketsphinx-plugin pocketsphinx-devel pocketsphinx-python pocketsphinx-models git python-setuptools python-lockfile
  ```
 
 2. Clone this repository: 


### PR DESCRIPTION
When trying to get sugarlistens running on fedora 20 machine, I found that there was one more dependency required, for the import lockfile. So the dependency "python-lockfile" should also be installed
